### PR TITLE
Remove extra newline in licence

### DIFF
--- a/create_licence_string.sh
+++ b/create_licence_string.sh
@@ -9,9 +9,9 @@ fi
 
 TMP_STR="verifaiLicence="
 while IFS= read -r line; do
-    TMP_STR="$TMP_STR\"$line\\\\\\\\n\" +\\\\n\\\\\\n\\"
+    TMP_STR="$TMP_STR\"$line\\\\\\\\n\" +\\\\\n\\"
 done <<< "$LICENCE_STR"
-TMP_STR=${TMP_STR::-15}
+TMP_STR=${TMP_STR::-13}
 echo ""
 printf "$TMP_STR\""
 echo ""


### PR DESCRIPTION
The last '\n' in the output of the create_license_string script causes
`"D/error: Licence is not valid. Please call Verifai.setLicence(...) with a valid licence"`
 