### PR TITLE
Pass correct context to startNfc

### DIFF
--- a/java/app/src/main/java/com/verifai/example/MainActivity.java
+++ b/java/app/src/main/java/com/verifai/example/MainActivity.java
@@ -171,7 +171,7 @@ public class MainActivity extends Activity {
         this.findViewById(R.id.start_nfc).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                startNfc(getBaseContext());
+                startNfc(MainActivity.this);
             }
         });
     }


### PR DESCRIPTION
Fixes error on Android 10 when starting NFC scan
`Calling startActivity() from outside of an Activity context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?`